### PR TITLE
Add DB pool and basic login test

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,5 +1,3 @@
-sql
-Copy code
 -- Users table
 CREATE TABLE Users (
     UserID INT PRIMARY KEY,

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "bubble-ai",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "body-parser": "^1.20.2",
+    "mysql": "^2.18.1"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "supertest": "^6.3.3"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,5 +1,15 @@
 const express = require('express');
 const bodyParser = require('body-parser');
+const mysql = require('mysql');
+
+// Basic MySQL connection pool. Adjust credentials as needed.
+const pool = mysql.createPool({
+  connectionLimit: 10,
+  host: 'localhost',
+  user: 'root',
+  password: '',
+  database: 'bubble'
+});
 
 const app = express();
 const port = 3000;
@@ -113,6 +123,10 @@ app.get('/news', (req, res) => {
   });
 
 // Start the server
-app.listen(port, () => {
-  console.log(`Server is running on http://localhost:${port}`);
-});
+if (require.main === module) {
+  app.listen(port, () => {
+    console.log(`Server is running on http://localhost:${port}`);
+  });
+}
+
+module.exports = app;

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -1,0 +1,20 @@
+const request = require('supertest');
+const app = require('../server');
+
+describe('POST /login', () => {
+  it('should login with valid credentials', async () => {
+    const res = await request(app)
+      .post('/login')
+      .send({ username: 'user1', password: 'password1' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.message).toBe('Login successful.');
+  });
+
+  it('should fail when username or password missing', async () => {
+    const res = await request(app)
+      .post('/login')
+      .send({});
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('Username and password are required.');
+  });
+});


### PR DESCRIPTION
## Summary
- define MySQL pool and export the Express app
- clean database schema header
- add Jest/Supertest test for `/login`
- provide package.json with dependencies

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486aaa4948832089c573a626e5b952